### PR TITLE
Download wheel from tagged release into PyPi

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -73,12 +73,68 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
-    - name: Build wheel
+    - name: Extract calling GitHub repository from archive_url
       shell: bash
+      env:
+        ARCHIVE_URL: ${{ inputs.archive_url }}
       run: |
-        pip install --upgrade build
-        python -m build --wheel
-        ls -lh dist/
+        # Extract the GitHub repo path from the archive URL
+        echo "Original archive URL: $ARCHIVE_URL"
+    
+        # Remove prefix and suffix
+        REPO_PATH=$(echo "$ARCHIVE_URL" | sed -E 's#.*github.com/([^\.]+/[^\.]+)\.git.*#\1#')
+    
+        echo "Extracted REPO_PATH: $REPO_PATH"
+    
+        # Export so future steps can use
+        echo "REPO_PATH=$REPO_PATH" >> "$GITHUB_ENV"
+
+    - name: Download wheel(s) from release
+      shell: bash
+      env:
+        # use github.token if inputs.github-token not provided
+        GH_TOKEN_INPUT: "${{ inputs.github-token }}"
+        GH_TOKEN_DEFAULT: "${{ github.token }}"
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: v${{ inputs.version }}
+        REPO: ${{ env.REPO_PATH }}
+      run: |
+        echo "Set up GH_TOKEN"
+        GH_TOKEN="${GH_TOKEN_DEFAULT}"
+        if [ -n "${GH_TOKEN_INPUT}" ]; then
+          echo "using GH_TOKEN_INPUT"
+          GH_TOKEN="${GH_TOKEN_INPUT}"
+        else
+          echo "using GH_TOKEN_DEFAULT"
+        fi
+        export GH_TOKEN
+        
+        echo "Fetching wheel URLs from release $REPO@$TAG..."
+        echo "TAG: $TAG"
+        echo "REPO: $REPO"
+
+        gh release view "$TAG" \
+          --repo "$REPO" \
+          --json assets \
+          --jq '.assets[] | select(.name | endswith(".whl")) | .url' > urls.txt
+
+        echo "Downloading wheel(s)..."
+        mkdir -p dist/
+        cd dist/
+        while read -r url; do
+          echo "Downloading $url..."
+          curl -L -H "Authorization: token $GH_TOKEN" -O "$url"
+        done < ../urls.txt
+
+        echo "✔️ Downloaded files:"
+        ls -lh
+        
+        wheel_file=$(ls | grep '\.whl$' | head -n 1)
+        echo "Found wheel file: $wheel_file"
+
+        # Save to environment for future steps
+        echo "WHEEL_FILENAME=$wheel_file" >> $GITHUB_ENV
+
 
     - name: upsert-package
       shell: bash
@@ -90,7 +146,15 @@ runs:
         commit_branch: "${{ inputs.commit_branch }}"
         root_dir: ${{ inputs.pypi_root_dir }}
         base_url: ${{ inputs.pypi_base_url }}
-      run: python "${GITHUB_ACTION_PATH}/src/main.py"
+      run: |
+        # Determine which archive URL to use
+        if [ -n "$WHEEL_FILENAME" ]; then
+          echo "Using wheel filename as archive URL: $WHEEL_FILENAME"
+          export python_service_archive_url="$WHEEL_FILENAME"
+        fi
+        
+        echo "Running main.py with archive URL: $python_service_archive_url"  
+        python "${GITHUB_ACTION_PATH}/src/main.py"
 
     - name: commit changes
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -73,6 +73,13 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
+    - name: Build wheel
+      shell: bash
+      run: |
+        pip install --upgrade build
+        python -m build --wheel
+        ls -lh dist/
+
     - name: upsert-package
       shell: bash
       env:

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,6 @@
 import os
 import hashlib
 import re
-import shutil
 from datetime import datetime
 
 
@@ -266,41 +265,6 @@ def upsert_package(root_dir, package_name, version, archive_url, archive_sha256,
     package_dir = os.path.join(root_dir, package_name_normalized)
     update_package_index(package_dir, package_name_normalized, version, archive_url, archive_sha256)
 
-
-def upsert_wheel_package(root_dir, package_name, version, archive_sha256, base_url):
-    # Find all .whl files in dist/
-    dist_dir = "dist"
-    wheels = [file for file in os.listdir(dist_dir) if file.endswith(".whl")]
-
-    if not wheels:
-        print("No .whl files found in dist/")
-        return
-
-    # Prepare internal PyPI directory
-    package_name_normalized = normalize(package_name)
-    package_dir = os.path.join(root_dir, package_name_normalized)
-    ensure_dir_exists(package_dir)
-
-    # Upsert each wheel into internal PyPI directory
-    for filename in wheels:
-        wheel_path = os.path.join(dist_dir, filename)
-        destination = os.path.join(package_dir, filename)
-
-        # Copy wheel into internal PyPI structure
-        shutil.copy(wheel_path, destination)
-
-        archive_url = f"{base_url}/{package_name_normalized}/{filename}"
-
-        upsert_package(
-            root_dir=root_dir,
-            package_name=package_name,
-            version=version,
-            archive_url=archive_url,
-            archive_sha256=archive_sha256,
-            base_url=base_url
-        )
-
-
 # set up main
 if __name__ == "__main__":
 
@@ -323,6 +287,3 @@ if __name__ == "__main__":
     base_url = os.environ.get('base_url')
     print("calling upsert_package")
     upsert_package(root_dir, package_name, version, archive_url, archive_sha256, base_url)
-
-    #TODO how to test
-    upsert_wheel_package(root_dir, package_name, version, archive_sha256, base_url)


### PR DESCRIPTION
Download wheel from tagged release (if any) into PyPi. It uses the regular archive_url if no wheel is present.
Goal: Make internal python packages installable via safe.txt

Ticket: https://app.asana.com/1/1203597261853496/project/1207422838103033/task/1207739419664772 

Testing:
Repos themselves will build the wheel: https://github.com/precedentai/python-internal-module-testing/blob/main/.github/workflows/pypi-publish.yaml#L34 
and be attached to the release
https://github.com/precedentai/python-internal-module-testing/releases/tag/v1.0.15

Simulated action.yaml from https://github.com/precedentai/python-internal-module-testing/blob/main/.github/workflows/upsert-package-test.yaml 

Happy Path Results:
https://github.com/precedentai/python-internal-module-testing/actions/runs/16206388084/job/45757538409

No Wheel Path Results (backwards compatibility):
https://github.com/precedentai/python-internal-module-testing/actions/runs/16221487031/job/45802845172


NOTE TODO: 
End to End Testing plan:
1. Put new PR Releases on hold
2. Stop auto generating PRs to PyPi
3. Tag a new release in python-internal-module-testing
4. Verify PyPI index.html and .whl file for internalmoduletesting
5. Add internalmoduletest==1.0.16 into {another_repo} in safe.txt
6. Verify with hello_world function that it works and internalmoduletest can be used.