### PR TITLE
Remove secrets var

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -95,7 +95,6 @@ runs:
         # use github.token if inputs.github-token not provided
         GH_TOKEN_INPUT: "${{ inputs.github-token }}"
         GH_TOKEN_DEFAULT: "${{ github.token }}"
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: v${{ inputs.version }}
         REPO: ${{ env.REPO_PATH }}
       run: |


### PR DESCRIPTION
{{ secrets }} var is only for non composite workflows. Was incorrectly copied over from previous GHA testing.
Composite actions do not have access to the secrets context themselves — it's the caller workflow that must pass any secrets via inputs or env.

GH_TOKEN is set in the script

Error thrown: https://github.com/precedentai/PyPI/actions/runs/16225046856/job/45814911119#step:1:31
Error: precedentai/github-actions-publish-github-pypi-handler/main/action.yaml (Line: 98, Col: 19): Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.GITHUB_TOKEN
