### PR TITLE
Normalize package name to match PyPi settings

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -187,7 +187,11 @@ runs:
           exit 0
         fi
     
-        target_dir="${root_dir}/${python_service_name}"
+        # Normalize per PEP 503: lowercase + replace [-_.]+ with single '-'
+        normalized_package_name="$(echo "$python_service_name" | tr '[:upper:]' '[:lower:]' | sed -E 's/[-_.]+/-/g')"
+
+        target_dir="${root_dir}/${normalized_package_name}"
+        
         mkdir -p "$target_dir"
         
         cp "dist/${WHEEL_FILENAME}" "$target_dir/"


### PR DESCRIPTION
Wheel should be saved to the same directory as its PyPi logic, which is the normalized package name.

Tested in internal module package
<img width="658" height="75" alt="image" src="https://github.com/user-attachments/assets/fb02b373-9659-4834-bbaa-57a6322f1ada" />

https://github.com/precedentai/python-internal-module-testing/actions/runs/16889757476/job/47846296167